### PR TITLE
fix: Added destructive fix for UnicodeDecodeError

### DIFF
--- a/utf8fixer.py
+++ b/utf8fixer.py
@@ -22,7 +22,7 @@ for arg in argv[2:]:
 
 def convert_file(file_path):
     print("[*]", file_path, "fixed!")
-    foriginal = copen(file_path, "r", "utf8")
+    foriginal = copen(file_path, "r", "utf8", errors='ignore')
     content = foriginal.read()
     foriginal.close()
 


### PR DESCRIPTION
This prevents the issue `UnicodeDecodeError: 'utf-8' codec can't decode byte ____ in position...` when processing a file with invalid bytes by removing the invalid content.

See: https://stackoverflow.com/a/48556203
See also: https://github.com/ItsIgnacioPortal/SecLists-Express/issues/16